### PR TITLE
Add Docker-based GitHub Actions Workflows

### DIFF
--- a/.github/workflows/lint-and-build-code.yml
+++ b/.github/workflows/lint-and-build-code.yml
@@ -1,0 +1,86 @@
+# Copyright 2020 Adam Chalkley
+#
+# https://github.com/atc0005/go-lockss
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+name: Validate Codebase
+
+# Run builds for Pull Requests (new, updated)
+# `synchronized` seems to equate to pushing new commits to a linked branch
+# (whether force-pushed or not)
+on:
+  #push:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  lint_code:
+    name: Lint codebase
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    container:
+      image: index.docker.io/atc0005/go-ci:go-ci-lint-only
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2.3.2
+
+      - name: Remove repo-provided golangci-lint config file
+        run: |
+          # Remove the copy of the config file bundled with the repo/code so
+          # that the configuration provided by the atc0005/go-ci project is
+          # used instead
+          rm -vf .golangci.yml
+
+      - name: Run golangci-lint using container-provided config file settings
+        run: golangci-lint run -v
+
+      # This is the very latest stable version of staticcheck provided by the
+      # atc0005/go-ci container. The version included with golangci-lint often
+      # lags behind the official stable releases.
+      - name: Run staticcheck
+        run: staticcheck $(go list -mod=vendor ./... | grep -v /vendor/)
+
+  test_code:
+    name: Run tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        container-image: ["go-ci-oldstable", "go-ci-stable", "go-ci-unstable"]
+
+    container:
+      image: "index.docker.io/atc0005/go-ci:${{ matrix.container-image}}"
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2.3.2
+
+      - name: Run all tests
+        run: go test -mod=vendor -v ./...
+
+  build_code:
+    name: Build codebase
+    runs-on: ubuntu-latest
+    # Default: 360 minutes
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        container-image: ["go-ci-oldstable", "go-ci-stable", "go-ci-unstable"]
+
+    container:
+      image: "index.docker.io/atc0005/go-ci:${{ matrix.container-image}}"
+
+    steps:
+      - name: Print go version
+        run: go version
+
+      - name: Check out code
+        uses: actions/checkout@v2.3.2
+
+      - name: Build using vendored dependencies
+        run: |
+          go build -v -mod=vendor ./cmd/hayoh
+          go build -v -mod=vendor ./cmd/n2n

--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -1,0 +1,75 @@
+# Copyright 2020 Adam Chalkley
+#
+# https://github.com/atc0005/go-lockss
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+name: Lint and Build using Makefile
+
+# Run builds for Pull Requests (new, updated)
+# `synchronized` seems to equate to pushing new commits to a linked branch
+# (whether force-pushed or not)
+on:
+  #push:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  lint_code_with_makefile:
+    name: Lint codebase using Makefile
+    runs-on: ubuntu-latest
+    # Default: 360 minutes
+    timeout-minutes: 10
+    container:
+      image: "index.docker.io/golang:latest"
+
+    steps:
+      - name: Print go version
+        run: go version
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2.3.2
+
+      # bsdmainutils provides "column" which is used by the Makefile
+      - name: Install Ubuntu packages
+        run: apt-get update && apt-get install -y --no-install-recommends make gcc bsdmainutils
+
+      - name: Install Go linting tools
+        run: make lintinstall
+
+      # NOTE: We are intentionally *not* removing the repo-provided config
+      # file (per GH-281) as this workflow is intended to emulate running the
+      # Makefile via a local dev environment.
+      #
+      # - name: Remove repo-provided golangci-lint config file
+      #   run: |
+      #     # Remove the copy of the config file bundled with the repo/code so
+      #     # that the configuration provided by the atc0005/go-ci project is
+      #     # used instead
+      #     rm -vf .golangci.yml
+
+      - name: Run Go linting tools using project Makefile
+        run: make linting
+
+  build_code_with_makefile:
+    name: Build codebase using Makefile
+    runs-on: ubuntu-latest
+    # Default: 360 minutes
+    timeout-minutes: 10
+    container:
+      image: "index.docker.io/golang:latest"
+
+    steps:
+      - name: Print go version
+        run: go version
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2.3.2
+
+      # bsdmainutils provides "column" which is used by the Makefile
+      - name: Install Ubuntu packages
+        run: apt-get update && apt-get install -y --no-install-recommends make gcc bsdmainutils
+
+      - name: Build using project Makefile
+        run: make all

--- a/.github/workflows/lint-and-test-only.yml
+++ b/.github/workflows/lint-and-test-only.yml
@@ -1,0 +1,39 @@
+# Copyright 2020 Adam Chalkley
+#
+# https://github.com/atc0005/go-lockss
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+name: Quick Validation
+
+# Run builds for Pull Requests (new, updated)
+# `synchronized` seems to equate to pushing new commits to a linked branch
+# (whether force-pushed or not)
+on:
+  push:
+
+jobs:
+  lint_and_test_code:
+    name: Lint and test using latest stable container
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    container:
+      image: index.docker.io/atc0005/go-ci:go-ci-lint-only
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2.3.2
+
+      - name: Remove repo-provided golangci-lint config file
+        run: |
+          # Remove the copy of the config file bundled with the repo/code so
+          # that the configuration provided by the atc0005/go-ci project is
+          # used instead
+          rm -vf .golangci.yml
+
+      - name: Run golangci-lint using container-provided config file settings
+        run: golangci-lint run -v
+
+      - name: Run all tests
+        run: go test -mod=vendor -v ./...

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -1,0 +1,48 @@
+# Copyright 2020 Adam Chalkley
+#
+# https://github.com/atc0005/go-lockss
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+name: Validate Docs
+
+# Run Workflow for Pull Requests (new, updated)
+# `synchronized` seems to equate to pushing new commits to a linked branch
+# (whether force-pushed or not)
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  lint_markdown:
+    name: Lint Markdown files
+    runs-on: "ubuntu-latest"
+    # Default: 360 minutes
+    timeout-minutes: 10
+
+    steps:
+      - name: Setup Node
+        # https://github.com/actions/setup-node
+        uses: actions/setup-node@v2.1.1
+        with:
+          # https://nodejs.org/en/about/releases/
+          node-version: "12"
+
+      - name: Install Markdown linting tools
+        run: |
+          npm install markdownlint --save-dev
+          npm install -g markdownlint-cli
+
+      - name: Check out code
+        uses: actions/checkout@v2.3.2
+
+      - name: Run Markdown linting tools
+        # The `.markdownlint.yml` file specifies config settings for this
+        # linter, including which linting rules to ignore.
+        #
+        # Note: Explicitly ignoring top-level vendor folder; we do not want
+        # potential linting issues in bundled documentation to fail linting CI
+        # runs for *our* documentation
+        run: |
+          markdownlint '**/*.md' --ignore node_modules --ignore vendor


### PR DESCRIPTION
## CHANGES

Add GitHub Actions which use containers created and managed through
the `atc0005/go-ci` project.

This results in three workflows:

- New, primary workflow
  - with parallel linting, testing and building tasks
  - with three Go environments
    - "old stable" - currently `Go 1.14.7`
    - "stable" - currently `Go 1.15.0`
    - "unstable" - currently `Go 1.15rc2`
      - this will be replaced with the next alpha, beta, rc release of
        Go and other linting tools that are not tested well enough to
        be considered "stable"
  - Makefile is *not* used in this workflow
  - `staticcheck` linting using latest stable version provided by the
    `atc0005/go-ci` containers

- Separate Makefile-based linting and building workflow
  - intended to help ensure that local Makefile-based
    builds that are referenced in project README files
    continue to work as advertised until a better local
    tool can be discovered/explored further
  - use `golang:latest` container to allow for Makefile-based
    linting tooling installation testing since the
    `atc0005/go-ci` project provides containers with those
    tools already pre-installed
    - linting tasks use container-provided `golangci-lint` config file
    *except* for the Makefile-driven linting task which continues to use
    the repo-provided copy of the `golangci-lint` configuration file

- Add Quick Validation workflow
  - run on every push, everything else on pull request updates
  - linting via `golangci-lint` only
  - testing
  - no builds

Other changes:

- Makefile `lintinstall` recipe installs the very latest
  stable version of the `golangci-lint` binary instead
  of locking a specific version
  - this should reduce dependency "gardening"

## REFERENCES

- fixes GH-5
- refs atc0005/todo#22
- see also the https://github.com/atc0005/go-ci project