### PR TITLE
Add license block to README, tweak copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Adam Chalkley
+Copyright (c) 2020-Present Adam Chalkley
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Go-based tooling for monitoring and troubleshooting LOCKSS nodes.
     - [`n2n`](#n2n)
     - [Worth noting](#worth-noting)
 - [Examples](#examples)
+- [License](#license)
 - [References](#references)
 
 ## Project home
@@ -180,6 +181,34 @@ application will be repurposed for that.
 ## Examples
 
 Placeholder :(
+
+## License
+
+Taken directly from the [`LICENSE`](LICENSE) file:
+
+```License
+MIT License
+
+Copyright (c) 2020-Present Adam Chalkley
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
 
 ## References
 


### PR DESCRIPTION
Note that it starts 2020, runs to present.

fixes GH-11