### PR TITLE
Makefile | Remove stray closing parenthesis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ WHAT 					= hayoh n2n
 # What package holds the "version" variable used in branding/version output?
 # VERSION_VAR_PKG			= $(shell go list .)
 # VERSION_VAR_PKG			= main
-VERSION_VAR_PKG			= $(shell go list .)/internal/config)
+VERSION_VAR_PKG			= $(shell go list .)/internal/config
 
 OUTPUTDIR 				= release_assets
 


### PR DESCRIPTION
Remove closing parenthesis that breaks embedding the repo version number within generated executables.