### PR TITLE
Use PortsScanned method for summary output

### DIFF
--- a/internal/portchecks/summary.go
+++ b/internal/portchecks/summary.go
@@ -87,7 +87,7 @@ func (rs Results) PrintSummary() {
 		"- %.0f%% (%d/%d) of ports scanned are reachable from this system.\n",
 		pPortsReachable,
 		portsReachable,
-		len(rs),
+		portsScanned,
 	)
 	fmt.Println()
 


### PR DESCRIPTION
Use earlier output from `rs.PortsScanned()` vs trying to calculate on the spot the count of entries in the results set to determine the number of ports scanned.

Right now the two produce the same results, but using the method is likely to continue giving the expected results after any future refactoring.