### PR TITLE
HOTFIX | Apply exact path match for peers list

### DIFF
--- a/internal/lockss/peers.go
+++ b/internal/lockss/peers.go
@@ -71,7 +71,7 @@ func (l IDInitialV3Peers) List() ([]V3Peer, error) {
 		return nil, fmt.Errorf("error compiling regex: %w", regExCompileErr)
 	}
 
-	xpathExpression := "//property[@name='id.initialV3PeerList']//list/value"
+	xpathExpression := "//property[@name='org.lockss']/property[@name='id.initialV3PeerList']/list/value"
 
 	xmlqueryNodes, err := xmlquery.QueryAll(l.xmlDoc, xpathExpression)
 	if err != nil {


### PR DESCRIPTION
This is not the long-term fix, but for now this commit updates the xpath expression to match *exactly* the XML document structure used in non-group-based LOCKSS networks to define peer nodes.

This change causes the application to "fail fast" when used on a LOCKSS node which *does* participate in a network which uses group-based peers lists.

refs GH-21