### PR TITLE
LOCKSS daemon config parsing: Skip blank lines

### DIFF
--- a/internal/lockss/load.go
+++ b/internal/lockss/load.go
@@ -327,6 +327,17 @@ func getLocalDaemonConfig(filename string, ignorePrefix string) (daemonConfig, e
 			currentLine,
 		)
 
+		// explicitly ignore blank lines
+		if currentLine == "" {
+			logger.Printf(
+				"%s: Line %d from %q appears to only contain whitespace, skipping ...",
+				myFuncName,
+				lineno,
+				filename,
+			)
+			continue
+		}
+
 		// explicitly ignore lines beginning with specified pattern, if
 		// provided
 		if ignorePrefix != "" {


### PR DESCRIPTION
Evidently this support was missing. Blank lines are now skipped
as intended when parsing the local LOKCSS daemon config file
(usually found at /etc/lockss/config.dat).

refs GH-26