### PR TITLE
Fix typo in config Stringer implementation

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -141,7 +141,7 @@ func (c Config) String() string {
 	return fmt.Sprintf(
 		"Config: { ConfigFile: %v, ConfigServerURL: %v, ConfigServerReadTimeout: %v, "+
 			"PortConnectTimeout: %v, LogFormat: %v, LogLevel: %v, UserNodePorts: %v, "+
-			"ShortVersion: %v}",
+			"ShowVersion: %v}",
 		c.ConfigFile(),
 		c.ConfigServerURL(),
 		c.ConfigServerReadTimeout(),


### PR DESCRIPTION
This commit fixes the name of one of the getter method names referenced in the String() method output.