### PR TITLE
Adjust the default port connection timeout to 2s

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,7 +50,7 @@ const (
 	defaultDisplayVersionAndExit bool   = false
 	defaultConfigFile            string = ""
 	defaultConfigReadTimeout            = 10
-	defaultPortConnectTimeout           = 1
+	defaultPortConnectTimeout           = 2
 )
 
 // multiIntValueFlag is a custom type that satisfies the flag.Value interface


### PR DESCRIPTION
Adding 1s delay to the check process per peer (checked simultaneously) shouldn't impact the user experience too much, and should hopefully help with any peer nodes that are on poor quality connections.