### PR TITLE
Add support for group-based peer nodes

### DIFF
--- a/docs/lockss-group-based-peers-sample.xml
+++ b/docs/lockss-group-based-peers-sample.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE lockss-config[
+<!ELEMENT lockss-config (if|property)+>
+<!ELEMENT property (property|list|value|if)*>
+<!ELEMENT list (value)+>
+<!ELEMENT value (#PCDATA)>
+<!ELEMENT test EMPTY>
+<!ELEMENT and (and|or|not|test)*>
+<!ELEMENT or (and|or|not|test)*>
+<!ELEMENT not (and|or|not|test)*>
+<!ELEMENT if (and|or|not|then|else|test|property)*>
+<!ELEMENT then (if|property)*>
+<!ELEMENT else (if|property)*>
+<!ATTLIST property name CDATA #REQUIRED>
+<!ATTLIST property value CDATA #IMPLIED>
+<!ATTLIST test hostname CDATA #IMPLIED>
+<!ATTLIST test group CDATA #IMPLIED>
+<!ATTLIST test daemonVersionMin CDATA #IMPLIED>
+<!ATTLIST test daemonVersionMax CDATA #IMPLIED>
+<!ATTLIST test daemonVersion CDATA #IMPLIED>
+<!ATTLIST test platformVersionMin CDATA #IMPLIED>
+<!ATTLIST test platformVersionMax CDATA #IMPLIED>
+<!ATTLIST test platformVersion CDATA #IMPLIED>
+<!ATTLIST test platformName CDATA #IMPLIED>
+<!ATTLIST if hostname CDATA #IMPLIED>
+<!ATTLIST if group CDATA #IMPLIED>
+<!ATTLIST if daemonVersionMin CDATA #IMPLIED>
+<!ATTLIST if daemonVersionMax CDATA #IMPLIED>
+<!ATTLIST if daemonVersion CDATA #IMPLIED>
+<!ATTLIST if platformVersionMin CDATA #IMPLIED>
+<!ATTLIST if platformVersionMax CDATA #IMPLIED>
+<!ATTLIST if platformVersion CDATA #IMPLIED>
+<!ATTLIST if platformName CDATA #IMPLIED>
+]>
+
+<lockss-config>
+    <property name="org.lockss">
+        <if>
+            <or>
+                <test group="abc" />
+                <test group="def" />
+                <test group="prod" />
+                <test group="hij" />
+            </or>
+            <then>
+                <property name="id.initialV3PeerList">
+                    <list>
+                        <value>TCP:[1.2.3.4]:9729</value>
+                        <value>TCP:[5.6.7.8]:9729</value>
+                    </list>
+                </property>
+            </then>
+        </if>
+        <if>
+            <or>
+                <test hostname="test1.example.org"/>
+                <test hostname="test2.example.org"/>
+                <test hostname="test3.example.org"/>
+                <test hostname="test4.example.org"/>
+            </or>
+            <then>
+                <property name="id.initialV3PeerList">
+                    <list>
+                        <value>TCP:[4.3.2.1]:9729</value>
+                        <value>TCP:[8.7.6.5]:9729</value>
+                    </list>
+                </property>
+            </then>
+        </if>
+    </property>
+</lockss-config>

--- a/internal/lockss/config.go
+++ b/internal/lockss/config.go
@@ -42,6 +42,12 @@ func New() (*Config, error) {
 
 	myFuncName := caller.GetFuncName()
 
+	logger.Printf(
+		"%s: parsing local LOCKSS daemon configuration file %q\n",
+		myFuncName,
+		DefaultConfigFile,
+	)
+
 	// parse the local LOCKSS Daemon configuration file for available settings
 	localDaemonCfg, err := getLocalDaemonConfig(DefaultConfigFile, ConfigFileCommentChar)
 	if err != nil {
@@ -51,6 +57,11 @@ func New() (*Config, error) {
 			DefaultConfigFile,
 		)
 	}
+
+	logger.Printf(
+		"%s: retrieving local LOCKSS daemon config settings",
+		myFuncName,
+	)
 
 	// Retrieve the URL configured within the local LOCKSS daemon
 	// configuration file

--- a/internal/lockss/doc.go
+++ b/internal/lockss/doc.go
@@ -5,5 +5,8 @@
 // Licensed under the MIT License. See LICENSE file in the project root for
 // full license information.
 
-// Package lockss assists with LOCKSS related configuration settings
+// Package lockss assists with LOCKSS related configuration settings.
+//
+// The plan is to export this package at some point for external project use,
+// but only once the API has settled.
 package lockss

--- a/internal/portchecks/portchecks.go
+++ b/internal/portchecks/portchecks.go
@@ -67,8 +67,8 @@ func CheckPort(netAddr net.Addr, port int, timeout time.Duration) Result {
 	// // force int64 to int type in order to fit into our Result struct
 	// port := int(portInt)
 
-	log.Debugf("Host: %s", host)
-	log.Debugf("Port: %d", port)
+	log.Debugf("%s: Host: %s", myFuncName, host)
+	log.Debugf("%s: Port: %d", myFuncName, port)
 
 	conn, err := net.DialTimeout(netAddr.Network(), netAddr.String(), timeout)
 	if err != nil {


### PR DESCRIPTION
## SUMMARY

Worth noting up front: I'm new to the internals of LOCKSS and am
figuring this out as I go.

Based on testing, I found that our LOCKSS nodes are each members of a
preservation group. LOCKSS networks may use these groups to control
which peers a specific node communicates with; I've personally seen
two networks where this doesn't apply and one where it does (a much
larger network).

The preservation group a node uses for locating its peers is
configured via the `LOCKSS_TEST_GROUP` setting found within
`/etc/lockss/config.dat`.

In order to properly determine what peers *should* be reachable, this
application MUST take the preservation group into account when parsing
the configuration/properties settings provided by the applicable
LOCKSS network configuration server. If not, more "failed nodes" will
be reported by this application than is truly the case.

## CHANGES

- Use a set of XPath expressions vs a single, hard-coded expression
    - first check to see if the preservation group defined for the
      node is in-use within the LOCKSS network
      configuration/properties file
    - if it is, use a XPath template that searches for peer nodes
      restricted to the set preservation group
    - if it is not, use a fixed XPath template that assumes a flat
      peer list is used
      - using a fixed XPath query is intended to help prevent
        false-positive matches for peers restricted to a specific host
        which might occur if the XPath query were more liberal
    - if all query attempts fail, bail out with an error

- Add sample file for use in future tests
  - `docs/lockss-group-based-peers-sample.xml`

- Add additional logging at points where the application can
  experience delays in operation

- Collapsed/simplified some debugging output
- `internal/lockss` package logging enabled if `debug` log level
  enabled for application

- Misc doc comment tweaks

## REFERENCES

- fixes GH-21
