### PR TITLE
gocritic | Fix commentFormatting linting errors

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -214,13 +214,13 @@ func NewConfig() (*Config, error) {
 
 	log.Debug("Validating configuration ...")
 	if err := config.Validate(); err != nil {
-		//flag.Usage()
+		// flag.Usage()
 		// Let app handle this directly
 		return nil, err
 	}
 	log.Debug("Configuration validated")
 
-	//log.Debugf("Config object: %v", config.String())
+	// log.Debugf("Config object: %v", config.String())
 
 	return &config, nil
 

--- a/internal/lockss/closet.go
+++ b/internal/lockss/closet.go
@@ -57,7 +57,7 @@ func NewConfig(xmlDoc *xmlquery.Node) (LOCKSSConfig, error) {
 
 // Content pulled from n2n "main":
 
-//fmt.Printf("Parsed document: %+v\n", doc)
+// fmt.Printf("Parsed document: %+v\n", doc)
 
 // appExitOnce := xmlquery.Find(doc, "//property//property[@name='app.exitOnce']")
 // fmt.Printf("Find results = Type: %T, Value: %+v\n", appExitOnce, appExitOnce)
@@ -83,13 +83,13 @@ func NewConfig(xmlDoc *xmlquery.Node) (LOCKSSConfig, error) {
 // 	os.Exit(1)
 // }
 
-//fmt.Printf("Find results = Type: %T, Value: %+v\n", ipInclude, ipInclude)
+// fmt.Printf("Find results = Type: %T, Value: %+v\n", ipInclude, ipInclude)
 
 // for _, item := range ipInclude {
 // 	fmt.Printf("%+v\n", item)
 // }
 
-//fmt.Printf("%+v\n", ipInclude.SelectElements("property"))
+// fmt.Printf("%+v\n", ipInclude.SelectElements("property"))
 
 /*
 

--- a/internal/lockss/load.go
+++ b/internal/lockss/load.go
@@ -216,7 +216,7 @@ func (c *Config) loadFromPropsURLWithContext(ctx context.Context, url string) (*
 			string(responseData),
 		)
 		logger.Println(warningStatusCodeMsg)
-		//return nil, warningStatusCodeMsg
+		// return nil, warningStatusCodeMsg
 
 	}
 

--- a/internal/lockss/proxy.go
+++ b/internal/lockss/proxy.go
@@ -7,10 +7,10 @@
 
 package lockss
 
-///////////////////////////////////////////////////////////////////////////////
+// /////////////////////////////////////////////////////////////////////////////
 // NOTE: This content is not currently used (stubbed out early on) and may be
 // removed in a future release.
-///////////////////////////////////////////////////////////////////////////////
+// /////////////////////////////////////////////////////////////////////////////
 
 // Proxy represents the parent proxy element containing settings related to
 // the content proxy support in LOCKSS
@@ -18,7 +18,7 @@ type Proxy struct {
 
 	// xmlDoc is the parse tree generated from the LOCKSS
 	// properties/configuration XML file by the xmlquery package.
-	//xmlDoc *xmlquery.Node
+	// xmlDoc *xmlquery.Node
 
 	NoManifestIndexResponses string
 	Port                     int
@@ -32,7 +32,7 @@ type ProxyAccess struct {
 
 	// xmlDoc is the parse tree generated from the LOCKSS
 	// properties/configuration XML file by the xmlquery package.
-	//xmlDoc *xmlquery.Node
+	// xmlDoc *xmlquery.Node
 
 	IPLogForbidden bool
 	IPInclude      []string

--- a/internal/portchecks/summary.go
+++ b/internal/portchecks/summary.go
@@ -19,7 +19,7 @@ import (
 // PrintSummary generates a table of all collected port check results
 func (rs Results) PrintSummary() {
 	w := new(tabwriter.Writer)
-	//w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, '.', tabwriter.AlignRight|tabwriter.Debug)
+	// w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, '.', tabwriter.AlignRight|tabwriter.Debug)
 
 	// Format in tab-separated columns
 	w.Init(os.Stdout, 16, 8, 8, '\t', 0)
@@ -36,7 +36,7 @@ func (rs Results) PrintSummary() {
 	fmt.Fprintln(w, "----\t----\t----\t-----\t")
 
 	sort.Slice(rs, func(i, j int) bool {
-		//return rs[i].Open < rs[j].Open
+		// return rs[i].Open < rs[j].Open
 		return rs[i].Open
 
 	})


### PR DESCRIPTION
Add spacing to resolve linting "errors".

fixes GH-42