### PR TITLE
Use default val consts instead of hard-coded vals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,25 @@ The following types of changes will be recorded in this file:
 
 - placeholder
 
+## [v0.1.3] - 2020-10-09
+
+### Added
+
+- static binaries
+
+### Changed
+
+- builds
+- deps
+
+### Fixed
+
+- YYYY-MM-DD format of changelog entries
+  - previous release
+
+- builds
+- config handling
+
 ## [v0.1.2] - 2020-8-20
 
 ### Added

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,6 +49,7 @@ const (
 	defaultLogFormat             string = "text"
 	defaultDisplayVersionAndExit bool   = false
 	defaultConfigFile            string = ""
+	defaultConfigServerURL       string = ""
 	defaultConfigReadTimeout            = 10
 	defaultPortConnectTimeout           = 2
 )

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -22,8 +22,8 @@ func (c *Config) handleFlagsConfig() {
 	flag.Var(&c.nodePorts, "p", nodePortFlagHelp+" (shorthand)")
 	flag.Var(&c.nodePorts, "port", nodePortFlagHelp)
 
-	flag.StringVar(&c.configServerURL, "cs", "", configServerURLFlagHelp+" (shorthand)")
-	flag.StringVar(&c.configServerURL, "config-server", "", configServerURLFlagHelp)
+	flag.StringVar(&c.configServerURL, "cs", defaultConfigServerURL, configServerURLFlagHelp+" (shorthand)")
+	flag.StringVar(&c.configServerURL, "config-server", defaultConfigServerURL, configServerURLFlagHelp)
 
 	flag.IntVar(&c.configServerReadTimeout, "ct", defaultConfigReadTimeout, configReadTimeoutFlagHelp+" (shorthand)")
 	flag.IntVar(&c.configServerReadTimeout, "config-read-timeout", defaultConfigReadTimeout, configReadTimeoutFlagHelp)

--- a/internal/config/getters.go
+++ b/internal/config/getters.go
@@ -33,44 +33,44 @@ func (c Config) UserNodePorts() []int {
 	}
 }
 
-// LogLevel returns the user-provided logging level or empty string if not
-// provided. CLI flag values take precedence if provided.
+// LogLevel returns the user-provided logging level or default log level if
+// not provided. CLI flag values take precedence if provided.
 func (c Config) LogLevel() string {
 
 	switch {
 	case c.logLevel != "":
 		return c.logLevel
 	default:
-		return ""
+		return defaultLogLevel
 	}
 }
 
-// LogFormat returns the user-provided logging format or empty string if not
-// provided. CLI flag values take precedence if provided.
+// LogFormat returns the user-provided logging format or default log format if
+// not provided. CLI flag values take precedence if provided.
 func (c Config) LogFormat() string {
 
 	switch {
 	case c.logFormat != "":
 		return c.logFormat
 	default:
-		return ""
+		return defaultLogFormat
 	}
 }
 
 // ConfigServerURL returns the user-provided URL to the LOCKSS
-// configuration/property XML file.
+// configuration/property XML file or the default value if not provided.
 func (c Config) ConfigServerURL() string {
 
 	switch {
 	case c.configServerURL != "":
 		return c.configServerURL
 	default:
-		return ""
+		return defaultConfigServerURL
 	}
 }
 
 // ConfigFile returns the user-provided path to the on-disk LOCKSS
-// configuration/property XML file.
+// configuration/property XML file or the default value if not provided.
 func (c Config) ConfigFile() string {
 
 	switch {


### PR DESCRIPTION
- add missing default value const for config server url
- actually *use* default value consts for log level, format

fixes atc0005/go-lockss#39
refs atc0005/dnsc#108