### PR TITLE
Fix linting issues exposed by linter upgrades

### DIFF
--- a/internal/lockss/load.go
+++ b/internal/lockss/load.go
@@ -78,6 +78,10 @@ func (c *Config) loadFromPropsFile(filename string) (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error occurred opening file: %w", err)
 	}
+
+	// #nosec G307
+	// Believed to be a false-positive from recent gosec release
+	// https://github.com/securego/gosec/issues/714
 	defer func() {
 		if err := f.Close(); err != nil {
 			logger.Printf(
@@ -287,6 +291,10 @@ func getLocalDaemonConfig(filename string, ignorePrefix string) (daemonConfig, e
 			err,
 		)
 	}
+
+	// #nosec G307
+	// Believed to be a false-positive from recent gosec release
+	// https://github.com/securego/gosec/issues/714
 	defer func() {
 		if err := f.Close(); err != nil {
 			// Ignore "file already closed" errors

--- a/internal/lockss/peers.go
+++ b/internal/lockss/peers.go
@@ -79,6 +79,9 @@ func (l IDInitialV3Peers) List() ([]V3Peer, error) {
 		)
 	}
 
+	// nolint:gocritic
+	// refs https://github.com/atc0005/go-lockss/issues/96
+	// refs https://github.com/go-critic/go-critic/issues/209
 	re, regExCompileErr := regexp.Compile(v3PeerRegex)
 	if regExCompileErr != nil {
 		return nil, fmt.Errorf("error compiling regex: %w", regExCompileErr)


### PR DESCRIPTION
## Changes

### Ignore false-positive gosec G307 linting errors

- Issues reported after upgrading golangci-lint to v1.43.0.
- gosec was updated in that version from v2.8.1 to v2.9.1.

### Ignore gocritic `regexp.Compile()` linting error

I am already checking for the regex compile error and immediately returning the error if it occurs. I expect that the error wrapping I am providing will be more readable to users than an intentional panic induced
stack trace would be.

## References

- fixes GH-96
- fixes GH-97
- refs golangci/golangci-lint#2299