### PR TITLE
Apply Go 1.19 specific doc comments linting fixes

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,14 +1,13 @@
 /*
+Go-based tooling for working with LOCKSS systems.
 
- Go-based tooling for working with LOCKSS systems.
-
-PROJECT HOME
+# PROJECT HOME
 
 See our GitHub repo (https://github.com/atc0005/go-lockss) for the latest
 code, to file an issue or submit improvements for review and potential
 inclusion into the project.
 
-PURPOSE
+# PURPOSE
 
 Provide a set of library packages and tools to help with monitoring and
 troubleshooting LOCKSS nodes.
@@ -18,28 +17,24 @@ attempts to automatically obtain the list of peer nodes from a central LOCKSS
 property/configuration server and check access to 9729/tcp (LCAP) to determine
 whether the node is accessible for polling, voting and repair purposes.
 
-FEATURES
+# FEATURES
 
-• Single binary (which makes deployment to LOCKSS nodes easier)
+  - Single binary (which makes deployment to LOCKSS nodes easier)
+  - User configurable logging levels
+  - User configurable logging format
+  - User configurable timeouts (config file retrieval, port connection tests)
+  - User configurable location of LOCKSS configuration/property settings
+    (custom file or URL)
+  - User configurable *additional* TCP ports to check; the default is to scan
+    the LCAP port provided in the LOCKSS configuration/property XML file
 
-• User configurable logging levels
+# KNOWN ISSUES
 
-• User configurable logging format
+  - The prototype `cmd/n2n` binary is a stub application, not usable in its
+    current form.
 
-• User configurable timeouts (config file retrieval, port connection tests)
+# USAGE
 
-• User configurable location of LOCKSS configuration/property settings (custom file or URL)
-
-• User configurable *additional* TCP ports to check; the default is to scan the LCAP port provided in the LOCKSS configuration/property XML file
-
-KNOWN ISSUES
-
-• The prototype `cmd/n2n` binary is a stub application, not usable in its current form.
-
-USAGE
-
-• Use the `--help` flag for current options
-
+  - Use the `--help` flag for current options
 */
-
 package main

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -40,7 +40,8 @@ const (
 	LogLevelDebug string = "debug"
 )
 
-// 	apex/log Handlers
+// apex/log Handlers
+//
 // ---------------------------------------------------------
 // cli - human-friendly CLI output
 // discard - discards all logs


### PR DESCRIPTION
These changes are effectively a NOOP for earlier Go versions, but improve the formatting of rendered documentation.