### PR TITLE
Fix branding and version output

### DIFF
--- a/cmd/hayoh/main.go
+++ b/cmd/hayoh/main.go
@@ -35,7 +35,10 @@ func main() {
 	switch {
 	// TODO: How else to guard against nil cfg object?
 	case appCfg != nil && appCfg.ShowVersion():
-		config.Branding()
+		fmt.Fprintln(
+			flag.CommandLine.Output(),
+			config.Branding(),
+		)
 		os.Exit(0)
 	case err == nil:
 		// do nothing for this one
@@ -62,7 +65,7 @@ func main() {
 		"\n[%v] Starting %s version %q ...\n",
 		time.Now().Format("2006-01-02 15.04:05"),
 		config.MyBinaryName(),
-		config.Version,
+		config.Version(),
 	)
 
 	// If user supplied values, we should use those to retrieve the LOCKSS

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,17 +19,17 @@ import (
 	"github.com/atc0005/go-lockss/internal/caller"
 )
 
-// Version reflects the application version. This is overridden via Makefile
+// version reflects the application version. This is overridden via Makefile
 // for release builds.
-var Version = "dev build"
+var version = "dev build"
 
-// MyAppName is the branded name of this application/project. This value will
+// myAppName is the branded name of this application/project. This value will
 // be used in user-facing output.
-const MyAppName string = "go-lockss"
+const myAppName string = "go-lockss"
 
-// MyAppURL is the branded homepage or project repo location. This value will
+// myAppURL is the branded homepage or project repo location. This value will
 // be used in user-facing output.
-const MyAppURL string = "https://github.com/atc0005/" + MyAppName
+const myAppURL string = "https://github.com/atc0005/" + myAppName
 
 const (
 	versionFlagHelp            = "Whether to display application version and then immediately exit application."
@@ -154,15 +154,14 @@ func (c Config) String() string {
 	)
 }
 
-// Branding is responsible for emitting application name, version and origin
-func Branding() {
-	fmt.Fprintf(
-		flag.CommandLine.Output(),
-		"\n%s %s\n%s\n\n",
-		MyAppName,
-		Version,
-		MyAppURL,
-	)
+// Version emits application version string.
+func Version() string {
+	return version
+}
+
+// Branding is responsible for emitting application name, version and origin.
+func Branding() string {
+	return fmt.Sprintf("%s %s (%s)", myAppName, version, myAppURL)
 }
 
 // MyBinaryName returns the name of this binary


### PR DESCRIPTION
## Changes

- unexport branding values
- rework config.Branding func to have caller control output sink
- add config.Version func to expose internal version value

This is a response to the Makefile changes that were made as part of adding container build support. Instead of modifying the Makefile settings to match previous package variable visiblity, we modify the package variable handling instead to more closely match how other projects are handling this value.

## References

- fixes GH-203