### PR TITLE
Fix goconst linting errors

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,10 @@ const (
 	nodePortFlagHelp           = "Additional TCP port to connect to on remote LOCKSS nodes to verify connectivity. This flag may be repeated for each additional TCP port to check. If not set, this application connects only to the port (usually 9729) specified in the LOCKSS configuration/property XML file."
 )
 
+// shorthandFlagSuffix is appended to short flag help text to emphasize that
+// the flag is a shorthand version of a longer flag.
+const shorthandFlagSuffix = " (shorthand)"
+
 // Default flag settings if not overridden by user input. Some constants are
 // untyped in order to allow type promotion as needed.
 const (

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -19,30 +19,30 @@ func (c *Config) handleFlagsConfig() {
 
 	log.Debugf("Before parsing flags: %v", c.String())
 
-	flag.Var(&c.nodePorts, "p", nodePortFlagHelp+" (shorthand)")
+	flag.Var(&c.nodePorts, "p", nodePortFlagHelp+shorthandFlagSuffix)
 	flag.Var(&c.nodePorts, "port", nodePortFlagHelp)
 
-	flag.StringVar(&c.configServerURL, "cs", defaultConfigServerURL, configServerURLFlagHelp+" (shorthand)")
+	flag.StringVar(&c.configServerURL, "cs", defaultConfigServerURL, configServerURLFlagHelp+shorthandFlagSuffix)
 	flag.StringVar(&c.configServerURL, "config-server", defaultConfigServerURL, configServerURLFlagHelp)
 
-	flag.IntVar(&c.configServerReadTimeout, "ct", defaultConfigReadTimeout, configReadTimeoutFlagHelp+" (shorthand)")
+	flag.IntVar(&c.configServerReadTimeout, "ct", defaultConfigReadTimeout, configReadTimeoutFlagHelp+shorthandFlagSuffix)
 	flag.IntVar(&c.configServerReadTimeout, "config-read-timeout", defaultConfigReadTimeout, configReadTimeoutFlagHelp)
 
-	flag.IntVar(&c.portConnectTimeout, "pt", defaultPortConnectTimeout, portConnectTimeoutFlagHelp+" (shorthand)")
+	flag.IntVar(&c.portConnectTimeout, "pt", defaultPortConnectTimeout, portConnectTimeoutFlagHelp+shorthandFlagSuffix)
 	flag.IntVar(&c.portConnectTimeout, "port-timeout", defaultPortConnectTimeout, portConnectTimeoutFlagHelp)
 
-	flag.StringVar(&c.configFile, "cf", defaultConfigFile, configFileFlagHelp+" (shorthand)")
+	flag.StringVar(&c.configFile, "cf", defaultConfigFile, configFileFlagHelp+shorthandFlagSuffix)
 	flag.StringVar(&c.configFile, "config-file", defaultConfigFile, configFileFlagHelp)
 
 	flag.BoolVar(&c.showVersion, "version", defaultDisplayVersionAndExit, versionFlagHelp)
-	flag.BoolVar(&c.showVersion, "v", defaultDisplayVersionAndExit, versionFlagHelp+" (shorthand)")
+	flag.BoolVar(&c.showVersion, "v", defaultDisplayVersionAndExit, versionFlagHelp+shorthandFlagSuffix)
 
 	// create shorter and longer logging level flag options
-	flag.StringVar(&c.logLevel, "ll", defaultLogLevel, logLevelFlagHelp+" (shorthand)")
+	flag.StringVar(&c.logLevel, "ll", defaultLogLevel, logLevelFlagHelp+shorthandFlagSuffix)
 	flag.StringVar(&c.logLevel, "log-level", defaultLogLevel, logLevelFlagHelp)
 
 	// create shorter and longer logging format flag options
-	flag.StringVar(&c.logFormat, "lf", defaultLogFormat, logFormatFlagHelp+" (shorthand)")
+	flag.StringVar(&c.logFormat, "lf", defaultLogFormat, logFormatFlagHelp+shorthandFlagSuffix)
 	flag.StringVar(&c.logFormat, "log-format", defaultLogFormat, logFormatFlagHelp)
 
 	flag.Usage = flagsUsage()


### PR DESCRIPTION
Replace literal text with new `shorthandFlagSuffix` config constant.