### PR TITLE
Fix `unused-parameter` revive linting error

### DIFF
--- a/internal/portchecks/summary.go
+++ b/internal/portchecks/summary.go
@@ -35,7 +35,7 @@ func (rs Results) PrintSummary() {
 	// Separator row; I'm sure this can be handled better
 	fmt.Fprintln(w, "----\t----\t----\t-----\t")
 
-	sort.Slice(rs, func(i, j int) bool {
+	sort.Slice(rs, func(i, _ int) bool {
 		// return rs[i].Open < rs[j].Open
 		return rs[i].Open
 


### PR DESCRIPTION
Resolve linting error flagged by recent linter releases (golangci-lint, revive).