### PR TITLE
Fix errcheck linting errors

### DIFF
--- a/cmd/hayoh/main.go
+++ b/cmd/hayoh/main.go
@@ -35,7 +35,7 @@ func main() {
 	switch {
 	// TODO: How else to guard against nil cfg object?
 	case appCfg != nil && appCfg.ShowVersion():
-		fmt.Fprintln(
+		_, _ = fmt.Fprintln(
 			flag.CommandLine.Output(),
 			config.Branding(),
 		)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -180,7 +180,7 @@ func flagsUsage() func() {
 
 		Branding()
 
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			flag.CommandLine.Output(),
 			"Usage of \"%s\":\n",
 			MyBinaryName(),

--- a/internal/portchecks/summary.go
+++ b/internal/portchecks/summary.go
@@ -27,13 +27,13 @@ func (rs Results) PrintSummary() {
 
 	// Add some lead-in spacing to better separate any earlier log messages from
 	// summary output
-	fmt.Fprintf(w, "\n")
+	_, _ = fmt.Fprintf(w, "\n")
 
 	// Header row in output
-	fmt.Fprintf(w, "Peer\tPort\tOpen\tError\t\n")
+	_, _ = fmt.Fprintf(w, "Peer\tPort\tOpen\tError\t\n")
 
 	// Separator row; I'm sure this can be handled better
-	fmt.Fprintln(w, "----\t----\t----\t-----\t")
+	_, _ = fmt.Fprintln(w, "----\t----\t----\t-----\t")
 
 	sort.Slice(rs, func(i, _ int) bool {
 		// return rs[i].Open < rs[j].Open
@@ -49,7 +49,7 @@ func (rs Results) PrintSummary() {
 		if item.Error != nil {
 			errText = item.Error.Error()
 		}
-		fmt.Fprintf(w,
+		_, _ = fmt.Fprintf(w,
 			"%s\t%d\t%t\t%s\t\n",
 			item.Host,
 			item.Port,
@@ -58,7 +58,7 @@ func (rs Results) PrintSummary() {
 		)
 	}
 
-	fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w)
 
 	hosts := rs.Hosts()
 	hostsReachable := rs.HostsReachable()


### PR DESCRIPTION
Resolve `return value of fmt.Fprintf is not checked`` errors by
explicitly discarding return values (potential error, bytes written)
since we do not need them and the potential for failure (in this
particular use case) is *highly* unlikely.
