### PR TITLE
Fix govet linting error raised by updated linter

### DIFF
--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -10,6 +10,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/apex/log"
@@ -67,7 +68,7 @@ func (c Config) Validate() error {
 				)
 				log.Debugf("%s: %v", myFuncName, errMsg)
 
-				return fmt.Errorf(errMsg)
+				return errors.New(errMsg)
 			}
 		}
 


### PR DESCRIPTION
Surfaced by golangci-lint v1.60.1 (built with Go 1.23.0).